### PR TITLE
Add an ability to use multiple badges in a left sidebar menu item wit…

### DIFF
--- a/widgets/Menu.php
+++ b/widgets/Menu.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2015 Yiister
- * @license https://github.com/yiister/yii2-adminlte/blob/master/LICENSE
+ * @license https://github.com/yiister/adminlte/blob/master/LICENSE
  * @link http://adminlte.yiister.ru
  */
 
@@ -21,7 +21,7 @@ class Menu extends \yii\widgets\Menu
     /**
      * @inheritdoc
      */
-    public $linkTemplate = '<a href="{url}">{icon}<span>{label}</span>{badge}</a>';
+    public $linkTemplate = '<a href="{url}">{icon}<span>{label}</span><span class="pull-right-container">{dropDownIcon}{badges}</span></a>';
 
     /**
      * @inheritdoc
@@ -48,11 +48,14 @@ class Menu extends \yii\widgets\Menu
     protected function renderItem($item)
     {
         $renderedItem = parent::renderItem($item);
-        if (isset($item['badge'])) {
-            $badgeOptions = ArrayHelper::getValue($item, 'badgeOptions', []);
-            Html::addCssClass($badgeOptions, 'label pull-right');
-        } else {
-            $badgeOptions = null;
+        $badges = '';
+        if (isset($item['badges']) && is_array($item['badges'])) {
+            foreach ($item['badges'] as $badge) {
+                $badgeContent = ArrayHelper::getValue($badge, 'content', '');
+                $badgeOptions = ArrayHelper::getValue($badge, 'badgeOptions', []);
+                Html::addCssClass($badgeOptions, 'label pull-right');
+                $badges .= Html::tag('small', $badgeContent, $badgeOptions);
+            }
         }
         return strtr(
             $renderedItem,
@@ -60,15 +63,12 @@ class Menu extends \yii\widgets\Menu
                 '{icon}' => isset($item['icon'])
                     ? new Icon($item['icon'], ArrayHelper::getValue($item, 'iconOptions', []))
                     : '',
-                '{badge}' => (
-                    isset($item['badge'])
-                        ? Html::tag('small', $item['badge'], $badgeOptions)
-                        : ''
-                    ) . (
-                    isset($item['items']) && count($item['items']) > 0
-                        ? new Icon('fa fa-angle-left pull-right')
-                        : ''
-                    ),
+                '{badges}' => ($badges != '')
+                    ? $badges
+                    : '',
+                '{dropDownIcon}' => isset($item['items']) && count($item['items']) > 0
+                    ? new Icon('fa fa-angle-left pull-right')
+                    : ''
             ]
         );
     }


### PR DESCRIPTION
…h sub items

Usage:

`[
	'label' => 'Personnes ', 'url' => './#', 'icon' => 'users',
	'badges' => [
	    ['content' => Personne::find()->count(), 'badgeOptions' => ['class' => 'bg-aqua']]
	],
	'items' => [
	    [
	        'label' => 'Liste des personnes',
	        'url' => ['/personne'],
	        'icon' => 'list'
	    ],
	    [
	        'label' => 'Ajouter une personne',
	        'url' => ['/personne/create'],
	        'icon' => 'plus'
	    ],
	],
]`

![20161222-2234](https://cloud.githubusercontent.com/assets/4754224/21460232/d9dcb5ae-c93d-11e6-9199-1c5d135d9813.png)
